### PR TITLE
Modify Prompt Generation Tool

### DIFF
--- a/assistant_agent/hello_agent.py
+++ b/assistant_agent/hello_agent.py
@@ -16,12 +16,12 @@ gcp_config = GCPConfig()
 system_prompt = (
     "You are a specialized AI assistant that helps users generate images and automatically stores them in Google Cloud Storage (GCS) based on their ideas."
     " You have access to the following tools:\n"
-    "- generate_prompts\n"
+    "- generate_prompts\n."
     "- generate_images\n"
     "When a user asks for an image, first consider if you need to generate a detailed prompt using generate_prompts based on the user's initial idea."
     " If you already have a suitable prompt or have just generated one, use generate_images to create and store the image(s) in GCS."
     " After generating the image(s), acknowledge that the image(s) have been created and stored in GCS, and show all the urls generated from the 'generate_image' tool. Save all the urls generated on each agent run."
-    " Inform the user the name of the image(s) and tell that the generated images will be deleted of Google Cloud in 7 days"
+    " Inform the user the name of the image(s) and tell that the generated images will be deleted of Google Cloud in 2 days."
 )
 model = GeminiModel(
     llm_config.AGENT_MODEL_NAME,

--- a/assistant_agent/tools/image_generator.py
+++ b/assistant_agent/tools/image_generator.py
@@ -134,7 +134,7 @@ async def generate_prompt_image(
 
 
 async def generate_prompts(
-    idea: str, general_image_name: str, n_images: int = 1
+    idea: str, general_image_name: str, n_prompts: int = 1
 ) -> list[dict]:
     """
     Generates n different prompts to further being used to generate
@@ -143,7 +143,7 @@ async def generate_prompts(
     Args:
         idea: str -> Idea of the user
         general_image_name: str -> General image name. Ex "waves_in_the_sea_at_sunset"
-        n_images: int -> Number of different images to create
+        n_prompts: int -> Number of different prompts to create based on the same idea.
 
     Returns:
         list[dict] -> List of dicionaries, the dictionary is a prompt, which keys must contain:
@@ -153,11 +153,11 @@ async def generate_prompts(
     """
     # Creating a list of prompt tasks
     prompt_tasks = list()
-    for _ in range(n_images):
+    for _ in range(n_prompts):
         task = generate_prompt_image(idea=idea)
         prompt_tasks.append(task)
 
-    logger.info("Generating prompt(s)...")
+    logger.info(f"Generating {n_prompts} prompt(s)...")
     prompts = await asyncio.gather(*prompt_tasks)
     logger.info("Prompt(s) generated")
 

--- a/assistant_agent/tools/image_generator.py
+++ b/assistant_agent/tools/image_generator.py
@@ -134,16 +134,15 @@ async def generate_prompt_image(
 
 
 async def generate_prompts(
-    idea: str, general_image_name: str, n_prompts: int = 1
+    ideas: list[str], general_images_names: list[str]
 ) -> list[dict]:
     """
     Generates n different prompts to further being used to generate
     n images.
 
     Args:
-        idea: str -> Idea of the user
-        general_image_name: str -> General image name. Ex "waves_in_the_sea_at_sunset"
-        n_prompts: int -> Number of different prompts to create based on the same idea.
+        ideas: list[str] -> List of different ideas to generate prompts from them. An entry of a list is one idea for a prompt
+        general_images_names: list[str] -> List of different names. The lenght of general_images_names and ideas must be the same
 
     Returns:
         list[dict] -> List of dicionaries, the dictionary is a prompt, which keys must contain:
@@ -153,11 +152,11 @@ async def generate_prompts(
     """
     # Creating a list of prompt tasks
     prompt_tasks = list()
-    for _ in range(n_prompts):
+    for idea in ideas:
         task = generate_prompt_image(idea=idea)
         prompt_tasks.append(task)
 
-    logger.info(f"Generating {n_prompts} prompt(s)...")
+    logger.info(f"Generating {len(ideas)} prompt(s)...")
     prompts = await asyncio.gather(*prompt_tasks)
     logger.info("Prompt(s) generated")
 
@@ -167,7 +166,7 @@ async def generate_prompts(
         # Generation of a dictionary to store the prompt info
         prompt_info = dict()
         prompt_info["prompt"] = prompt
-        prompt_info["image_name"] = f"{general_image_name}_{prompt_number}"
+        prompt_info["image_name"] = f"{general_images_names[prompt_number]}"
 
         requests.append(prompt_info)
 


### PR DESCRIPTION
The agent, before this PR, made unnecessary calls to this function due to it only generated n prompts for 1 single idea, so user's queries like 'Generate 3 images, 1 related to X, the other related to Y, and the final related to Z ', confused the agent, and it called the prompt_generation 3 times, but each prompt_generation had the parameter n_images = 3, so it generated 6 prompts in total, which reduced performance.

Now, this function was modified to accept n different ideas, so it allows the agent to generate 1 single call to the function with the necessary number of ideas, which really improves performance. Now, requests of n images can be executed in less than 1 min.