### PR TITLE
Agent concurrency

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append("../..")
 
 from app.backend.models import AgentRequest, AgentResponse
-from assistant_agent.agent import agent
+from assistant_agent.agent import generate_agent_instance
 from assistant_agent.agent_auxiliars import (
     prepare_to_read_chat_history,
     prepare_to_send_chat_history,
@@ -16,13 +16,16 @@ app = FastAPI()
 
 
 @app.post("/ask_agent", response_model=AgentResponse)
-def agent_request(request: AgentRequest):
+async def agent_request(request: AgentRequest):
+    logger.debug("Generating new agent instance...")
+    agent = generate_agent_instance()
+    logger.debug("Agent instance generated successfully")
     logger.info("Preparing chat history to be read by the agent...")
     chat_history = prepare_to_read_chat_history(request.chat_history)
     logger.info("History chat session prepared")
     logger.info("Sending new prompt to the agent...")
     try:
-        agent_answer = agent.run_sync(
+        agent_answer = await agent.run(
             request.current_user_prompt, message_history=chat_history
         )
         logger.info(f"Agent response:{agent_answer.output}")

--- a/assistant_agent/agent.py
+++ b/assistant_agent/agent.py
@@ -30,18 +30,34 @@ model = GeminiModel(
     provider=GoogleGLAProvider(api_key=llm_config.API_KEY.get_secret_value()),
 )
 
-agent = Agent(
-    model,
-    tools=[
-        Tool(generate_prompts, takes_ctx=False),
-        Tool(generate_images, takes_ctx=False),
-    ],
-    system_prompt=system_prompt,
-)
+
+def generate_agent_instance() -> Agent:
+    """
+    For each request, it will generate a new agent instance to avoid concurrency errors
+
+    Args:
+        None
+    Returns:
+        Agent -> Agent instance
+    """
+
+    agent = Agent(
+        model,
+        tools=[
+            Tool(generate_prompts, takes_ctx=False),
+            Tool(generate_images, takes_ctx=False),
+        ],
+        system_prompt=system_prompt,
+    )
+
+    return agent
+
 
 # This will execute the agent on the local console
 if __name__ == "__main__":
     logger.info("Starting Agent chat...")
+    logger.debug("Generating a new agent intance...")
+    agent = generate_agent_instance()
     request = input("Introduce a query (To exit, enter 'exit'):").strip()
     history = []
     while request != "exit":


### PR DESCRIPTION
When using two different instances of the API at the same time, an error occurred: Error calling agent. Status: 500. Details: {"detail":"<asyncio.locks.Event object at 0x3e3dd1bc6250 [unset]> is bound to a different event loop"}

This was because the agent instance was generated only once, when the API was instanciated, now the agent instance is created everytime the ask_agent endpoint is called to avoid this issue.