### PR TITLE
Fix Endpoint Models on Registration and Login

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -169,7 +169,7 @@ def add_user(user_data: User, response: Response):
             detail="An internal server error occurred while registering the user.",
         )
 
-    return TokenResponse(access_token=access_token)
+    return TokenResponse(access_token=access_token, username=user_data.full_name)
 
 
 @app.post(

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -5,7 +5,6 @@ from loguru import logger
 from app.backend.models import (
     AgentRequest,
     AgentResponse,
-    UserRegistrationResponse,
     TokenResponse,
     UserLoginRequest,
 )
@@ -137,7 +136,7 @@ async def agent_request(
 @app.post(
     api_config.CREATE_USER_ENDPOINT,
     status_code=status.HTTP_201_CREATED,
-    response_model=UserRegistrationResponse,
+    response_model=TokenResponse,
 )
 def add_user(user_data: User, response: Response):
     logger.info(f"Request to register email: {user_data.email}")
@@ -170,11 +169,7 @@ def add_user(user_data: User, response: Response):
             detail="An internal server error occurred while registering the user.",
         )
 
-    return UserRegistrationResponse(
-        user_id=user_id,
-        access_token=access_token,
-        username=user_data.full_name,
-    )
+    return TokenResponse(access_token=access_token)
 
 
 @app.post(

--- a/app/backend/models.py
+++ b/app/backend/models.py
@@ -33,14 +33,6 @@ class TokenData(BaseModel):
     user_id: str = USER_ID_FIELD
 
 
-class UserRegistrationResponse(TokenResponse):
-    user_id: str = USER_ID_FIELD
-    message: str = Field(
-        default="User successfully registered",
-        description="Message to return if the user was successfully registered",
-    )
-
-
 class UserLoginRequest(BaseModel):
     email: EmailStr = Field(description="User's email")
     password: SecretStr = PASSWORD_FIELD

--- a/app/frontend/login.py
+++ b/app/frontend/login.py
@@ -8,10 +8,10 @@ from assistant_agent.config import APIConfig
 
 
 # Logger configuration
-if "logger_configured_login_page" not in st.session_state:
+if "logger_level_configured" not in st.session_state:
     logger.remove()
     logger.add(sys.stderr, level="INFO")
-    st.session_state.logger_configured_login_page = True
+    st.session_state.logger_level_configured = True
 
 backend_config = APIConfig()
 pages_config = PagesConfig()

--- a/app/frontend/pages/chat_agent.py
+++ b/app/frontend/pages/chat_agent.py
@@ -1,15 +1,10 @@
 import streamlit as st
 from loguru import logger
 import requests
-import sys
 from app.frontend.utils import find_image_urls
 from app.frontend.config import PagesConfig
 from assistant_agent.config import APIConfig
 
-
-# Setting the logs level
-logger.remove()
-logger.add(sys.stderr, level="INFO")
 
 backend_config = APIConfig()
 pages_config = PagesConfig()

--- a/app/frontend/pages/registration_page.py
+++ b/app/frontend/pages/registration_page.py
@@ -73,21 +73,19 @@ with st.form("registration_form_main", clear_on_submit=False):
                 response = requests.post(add_user_url, json=payload, timeout=15)
                 if response.status_code == 201:
                     response_data = response.json()
-                    user_id = response_data.get("user_id")
+                    user_full_name = response_data.get("username")
                     access_token = response_data.get("access_token")
                     token_type = response_data.get("token_type")
 
                     st.success(
                         f"User '{reg_full_name}' registered successfully! Redirecting to chat..."
                     )
-                    logger.info(f"User {reg_email} registered with ID {user_id}")
 
                     # Storing session info
                     st.session_state.logged_in = True
-                    st.session_state.user_id = user_id
-                    st.session_state.user_full_name = reg_full_name
-                    st.session_state.user_email = reg_email
                     st.session_state.access_token = access_token
+                    st.session_state.user_email = reg_email
+                    st.session_state.user_full_name = user_full_name
 
                     st.balloons()
                     st.rerun()  # To force the verification of the login at the beginning and switch page

--- a/app/frontend/pages/registration_page.py
+++ b/app/frontend/pages/registration_page.py
@@ -6,10 +6,10 @@ from app.frontend.config import PagesConfig
 from assistant_agent.config import APIConfig
 
 
-if "logger_configured_main_app" not in st.session_state:
+if "logger_level_configured" not in st.session_state:
     logger.remove()
     logger.add(sys.stderr, level="INFO")
-    st.session_state.logger_configured_main_app = True
+    st.session_state.logger_level_configured = True
 
 
 backend_config = APIConfig()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,11 +61,11 @@ def test_add_user_success():
 
     assert response.status_code == status.HTTP_201_CREATED
     response_data = response.json()
-    assert "user_id" in response_data
-    assert isinstance(response_data["user_id"], str)
-    assert response_data["message"] == "User successfully registered"
+    assert "access_token" in response_data
+    assert "token_type" in response_data
+    assert "bearer" in response_data["token_type"]
+    assert "username" in response_data
     assert "Location" in response.headers
-    assert f"/users/{response_data['user_id']}" in response.headers["Location"]
 
 
 def test_add_user_conflict_email_already_registered():


### PR DESCRIPTION
- Now both endpoints, login and registration, uses the same response model
- Frontend modified to receive the response of the new class
- Keep the same chat session variable to set the logging level for each session 