### PR TITLE
Improve Ask Agent Endpoint

### DIFF
--- a/app/backend/models.py
+++ b/app/backend/models.py
@@ -8,17 +8,12 @@ from assistant_agent.schemas import (
 
 
 class AgentRequest(BaseModel):
-    chat_history: Optional[str] = Field(
-        default="[]",
-        description="History of the current chat",
-    )
     current_user_prompt: str = Field(description="User prompt", min_length=1)
     chat_session_id: Optional[str] = CHAT_SESSION_ID_FIELD
 
 
 class AgentResponse(BaseModel):
     agent_response: str = Field(description="Agent response")
-    current_history: str = Field(description="Whole chat session history")
     chat_session_id: str = CHAT_SESSION_ID_FIELD
 
 

--- a/app/frontend/pages/chat_agent.py
+++ b/app/frontend/pages/chat_agent.py
@@ -39,7 +39,7 @@ if not st.session_state.get("logged_in") or not st.session_state.get("access_tok
             "Go to Registration", key="chat_goto_reg", use_container_width=True
         ):
             st.switch_page(pages_config.registration)
-    st.stop()  # Detener la ejecución de esta página si no está logueado
+    st.stop()  # Stop execution if not logged
 
 
 # Log out button in the lateral bar
@@ -48,14 +48,11 @@ with st.sidebar:
     st.write(f"Welcome, {first_name}!")
     if st.session_state.get("user_email"):
         st.caption(f"Email: {st.session_state.get('user_email')}")
-    if st.session_state.get("user_id"):
-        st.caption(f"UserID: {st.session_state.get('user_id')}")
 
     if st.button("Logout", key="logout_button_chat", use_container_width=True):
         logger.info(f"{first_name} logging out.")
         keys_to_clear = [
             "logged_in",
-            "user_id",
             "user_full_name",
             "user_email",
             "access_token",

--- a/assistant_agent/agent.py
+++ b/assistant_agent/agent.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     history = []
     while request != "exit":
         result = agent.run_sync(request, message_history=history)
-        history = result.all_messages()
+        history = result.all_messages()  # list of ModelRequest objects
         history_json = result.all_messages_json()
         logger.debug(f"{history_json=}")
         logger.info(f"{result.output}")

--- a/assistant_agent/auxiliars/agent_auxiliars.py
+++ b/assistant_agent/auxiliars/agent_auxiliars.py
@@ -1,5 +1,6 @@
 from pydantic_core import to_jsonable_python
 from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelMessage
+import json
 
 
 def prepare_to_read_chat_history(chat_history: list[dict]) -> list[ModelMessage]:
@@ -22,6 +23,27 @@ def prepare_to_read_chat_history(chat_history: list[dict]) -> list[ModelMessage]
     chat_history = ModelMessagesTypeAdapter.validate_python(chat_history)
 
     return chat_history
+
+
+def get_new_agent_steps(previous_steps: list[dict], all_steps: bytes):
+    """
+    Process the previous_steps and the new one to store only the new history generated
+
+    Args:
+        previous_steps: list[dict] -> List of dictionaries, each dictionary is an agent step
+                                        that was already stored in the database
+        all_steps: bytes -> binary string obtained after making agent.all_messages_json()
+
+    Returns: -> list[dict] -> List of the new agent steps generated
+    """
+    # Convert it into a list of dictionaries
+    all_steps = json.loads(all_steps)
+
+    number_new_steps = len(previous_steps) - len(all_steps)  # always a negative number
+
+    new_steps = all_steps[number_new_steps:]
+
+    return new_steps
 
 
 def prepare_to_send_chat_history(chat_history: bytes) -> str:

--- a/assistant_agent/auxiliars/agent_auxiliars.py
+++ b/assistant_agent/auxiliars/agent_auxiliars.py
@@ -1,21 +1,19 @@
 from pydantic_core import to_jsonable_python
 from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelMessage
-import json
 
 
-def prepare_to_read_chat_history(chat_history: str) -> list[ModelMessage]:
+def prepare_to_read_chat_history(chat_history: list[dict]) -> list[ModelMessage]:
     """
-    Convert a chat sessions that is obtained in a json string format into a list[ModelMessage]
-    that the agent can read during chat sessions.
+    Convert a chat session history that is obtained as a list of dictionaries and
+    transform it into a list[ModelMessage] that the agent can read during chat sessions.
 
     Args:
-        chat_history: str -> JSON string containing all the chat session history
+        chat_history: list[dict] -> list of dictionaries obtained fron the database, this contains all the
+                                    agent steps, not only the answer/response
 
     Returns:
         list[ModelMessage] -> List of ModelMessage objects that the agent can process
     """
-    # Convert the JSON string into a list of dictionaries
-    chat_history = json.loads(chat_history)
 
     # Validates the structure of the python objects
     chat_history = to_jsonable_python(chat_history)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,14 +32,16 @@ def test_ask_agent_success():
     """
     payload = {
         "current_user_prompt": "Hi, agent!",
-        "chat_history": "[]",
         "chat_session_id": None,
     }
 
     response = client.post(ask_agent_endpoint, json=payload)
 
+    response_data = response.json()
+
     assert response.status_code == 200
-    assert "current_history" in response.json().keys()
+    assert "chat_session_id" in response_data
+    assert isinstance(response_data["chat_session_id"], str)
     assert "agent_response" in response.json().keys()
 
 


### PR DESCRIPTION
- The chat history is always obtained from the database
- The process of storage the agent steps now is paralyze to improve response time
- AgentRequests and AgentResponse classes now only asks for the chat_session_id to keep track of the conversation